### PR TITLE
issue-6: switch off MySQL initialize-insecure option

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
             MYSQL_DATABASE: '${DB_DATABASE}'
             MYSQL_USER: '${DB_USERNAME}'
             MYSQL_PASSWORD: '${DB_PASSWORD}'
-            MYSQL_ALLOW_EMPTY_PASSWORD: 1
+            MYSQL_ALLOW_EMPTY_PASSWORD: 0
         volumes:
             - 'sail-mysql:/var/lib/mysql'
             - './vendor/laravel/sail/database/mysql/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'


### PR DESCRIPTION
Resolves issue #6 - (ie. Laravel Sail no longer displays warning on startup).

## Changed
* **docker-compose.yml** -  Switch off the `--initialize-insecure` option
* **.env** -  Assign (new) MySQL service password *(shown below - no PR req'd since not committed to repo)*

`.env`: 16 - 
`DB_PASSWORD=password` -> `DB_PASSWORD={new_password_here}`
