### PR TITLE
Revert 068fe29 to enable Sail migration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
             MYSQL_DATABASE: '${DB_DATABASE}'
             MYSQL_USER: '${DB_USERNAME}'
             MYSQL_PASSWORD: '${DB_PASSWORD}'
-            MYSQL_ALLOW_EMPTY_PASSWORD: 0
+            MYSQL_ALLOW_EMPTY_PASSWORD: 1
         volumes:
             - 'sail-mysql:/var/lib/mysql'
             - './vendor/laravel/sail/database/mysql/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'


### PR DESCRIPTION
Part of series of smaller PRs based on (too-large) PR https://github.com/hfagerlund/quiz_app/pull/11.

## Changed
As mentioned in PR #11:
* Reverting 068fe29 and using it in combination with the (new) .env file (from PR #7 - ie. with the changed/new password) were required in order for the following to work: 
```console
$ ./vendor/bin/sail artisan migrate
```
