### PR TITLE
Create GraphQL Types

### DIFF
--- a/app/GraphQL/Types/HintType.php
+++ b/app/GraphQL/Types/HintType.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Types;
+
+use App\Models\Hint;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\Type as GraphQLType;
+
+class HintType extends GraphQLType
+{
+    protected $attributes = [
+        'name' => 'Hint',
+        'description' => 'A type'
+    ];
+
+    public function fields(): array
+    {
+        return [
+            'id' => [
+                'type' => Type::nonNull(Type::int()),
+                'description' => 'ID of hint'
+            ],
+            'hint' => [
+                'type' => Type::nonNull(Type::string()),
+                'description' => 'Content of the hint'
+            ],
+            'question' => [
+                'type' => GraphQL::type('Question'),
+                'description' => 'The question associated with the hint'
+            ]
+        ];
+    }
+}

--- a/app/GraphQL/Types/QuestionType.php
+++ b/app/GraphQL/Types/QuestionType.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Types;
+use App\Models\Question;
+use GraphQL\Type\Definition\Type;
+use Rebing\GraphQL\Support\Facades\GraphQL;
+use Rebing\GraphQL\Support\Type as GraphQLType;
+
+class QuestionType extends GraphQLType
+{
+    protected $attributes = [
+        'name' => 'Question',
+        'description' => 'A type'
+    ];
+
+    public function fields(): array
+    {
+        return [
+            'id' => [
+                'type' => Type::id(),
+                'description' => 'Auto-incremented ID of question'
+            ],
+            'title' => [
+                'type' => Type::nonNull(Type::string()),
+                'description' => 'Title of the question'
+            ],
+            'body' => [
+                'type' => Type::nonNull(Type::string()),
+                'description' => 'Content of the question'
+            ],
+            'hints' => [
+                'type' => Type::listOf(GraphQL::type('Hint')),
+                'description' => 'List of hints per question'
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
Resolves #17.

## Changed
* Generate GraphQL types using: 
```console
$ ./vendor/bin/sail artisan make:graphql:type QuestionType
```
* Add attributes, fields for GraphQL types