### PR TITLE
Fix lockfile after npm version upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,197 +1,421 @@
 {
+    "name": "html",
+    "lockfileVersion": 3,
     "requires": true,
-    "lockfileVersion": 1,
-    "dependencies": {
-        "@babel/parser": {
+    "packages": {
+        "": {
+            "dependencies": {
+                "vue": "^3.2.36",
+                "vue-loader": "^17.0.1"
+            },
+            "devDependencies": {
+                "@vitejs/plugin-vue": "^4.2.1",
+                "axios": "^1.1.2",
+                "laravel-vite-plugin": "^0.7.2",
+                "vite": "^4.0.0"
+            }
+        },
+        "node_modules/@babel/parser": {
             "version": "7.21.8",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.8.tgz",
-            "integrity": "sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA=="
+            "integrity": "sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA==",
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
         },
-        "@esbuild/android-arm": {
+        "node_modules/@esbuild/android-arm": {
             "version": "0.17.18",
             "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.18.tgz",
             "integrity": "sha512-EmwL+vUBZJ7mhFCs5lA4ZimpUH3WMAoqvOIYhVQwdIgSpHC8ImHdsRyhHAVxpDYUSm0lWvd63z0XH1IlImS2Qw==",
+            "cpu": [
+                "arm"
+            ],
             "dev": true,
-            "optional": true
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
-        "@esbuild/android-arm64": {
+        "node_modules/@esbuild/android-arm64": {
             "version": "0.17.18",
             "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.18.tgz",
             "integrity": "sha512-/iq0aK0eeHgSC3z55ucMAHO05OIqmQehiGay8eP5l/5l+iEr4EIbh4/MI8xD9qRFjqzgkc0JkX0LculNC9mXBw==",
+            "cpu": [
+                "arm64"
+            ],
             "dev": true,
-            "optional": true
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
-        "@esbuild/android-x64": {
+        "node_modules/@esbuild/android-x64": {
             "version": "0.17.18",
             "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.18.tgz",
             "integrity": "sha512-x+0efYNBF3NPW2Xc5bFOSFW7tTXdAcpfEg2nXmxegm4mJuVeS+i109m/7HMiOQ6M12aVGGFlqJX3RhNdYM2lWg==",
+            "cpu": [
+                "x64"
+            ],
             "dev": true,
-            "optional": true
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
-        "@esbuild/darwin-arm64": {
+        "node_modules/@esbuild/darwin-arm64": {
             "version": "0.17.18",
             "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.18.tgz",
             "integrity": "sha512-6tY+djEAdF48M1ONWnQb1C+6LiXrKjmqjzPNPWXhu/GzOHTHX2nh8Mo2ZAmBFg0kIodHhciEgUBtcYCAIjGbjQ==",
+            "cpu": [
+                "arm64"
+            ],
             "dev": true,
-            "optional": true
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
-        "@esbuild/darwin-x64": {
+        "node_modules/@esbuild/darwin-x64": {
             "version": "0.17.18",
             "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.18.tgz",
             "integrity": "sha512-Qq84ykvLvya3dO49wVC9FFCNUfSrQJLbxhoQk/TE1r6MjHo3sFF2tlJCwMjhkBVq3/ahUisj7+EpRSz0/+8+9A==",
+            "cpu": [
+                "x64"
+            ],
             "dev": true,
-            "optional": true
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
-        "@esbuild/freebsd-arm64": {
+        "node_modules/@esbuild/freebsd-arm64": {
             "version": "0.17.18",
             "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.18.tgz",
             "integrity": "sha512-fw/ZfxfAzuHfaQeMDhbzxp9mc+mHn1Y94VDHFHjGvt2Uxl10mT4CDavHm+/L9KG441t1QdABqkVYwakMUeyLRA==",
+            "cpu": [
+                "arm64"
+            ],
             "dev": true,
-            "optional": true
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
-        "@esbuild/freebsd-x64": {
+        "node_modules/@esbuild/freebsd-x64": {
             "version": "0.17.18",
             "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.18.tgz",
             "integrity": "sha512-FQFbRtTaEi8ZBi/A6kxOC0V0E9B/97vPdYjY9NdawyLd4Qk5VD5g2pbWN2VR1c0xhzcJm74HWpObPszWC+qTew==",
+            "cpu": [
+                "x64"
+            ],
             "dev": true,
-            "optional": true
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
-        "@esbuild/linux-arm": {
+        "node_modules/@esbuild/linux-arm": {
             "version": "0.17.18",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.18.tgz",
             "integrity": "sha512-jW+UCM40LzHcouIaqv3e/oRs0JM76JfhHjCavPxMUti7VAPh8CaGSlS7cmyrdpzSk7A+8f0hiedHqr/LMnfijg==",
+            "cpu": [
+                "arm"
+            ],
             "dev": true,
-            "optional": true
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
-        "@esbuild/linux-arm64": {
+        "node_modules/@esbuild/linux-arm64": {
             "version": "0.17.18",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.18.tgz",
             "integrity": "sha512-R7pZvQZFOY2sxUG8P6A21eq6q+eBv7JPQYIybHVf1XkQYC+lT7nDBdC7wWKTrbvMXKRaGudp/dzZCwL/863mZQ==",
+            "cpu": [
+                "arm64"
+            ],
             "dev": true,
-            "optional": true
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
-        "@esbuild/linux-ia32": {
+        "node_modules/@esbuild/linux-ia32": {
             "version": "0.17.18",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.18.tgz",
             "integrity": "sha512-ygIMc3I7wxgXIxk6j3V00VlABIjq260i967Cp9BNAk5pOOpIXmd1RFQJQX9Io7KRsthDrQYrtcx7QCof4o3ZoQ==",
+            "cpu": [
+                "ia32"
+            ],
             "dev": true,
-            "optional": true
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
-        "@esbuild/linux-loong64": {
+        "node_modules/@esbuild/linux-loong64": {
             "version": "0.17.18",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.18.tgz",
             "integrity": "sha512-bvPG+MyFs5ZlwYclCG1D744oHk1Pv7j8psF5TfYx7otCVmcJsEXgFEhQkbhNW8otDHL1a2KDINW20cfCgnzgMQ==",
+            "cpu": [
+                "loong64"
+            ],
             "dev": true,
-            "optional": true
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
-        "@esbuild/linux-mips64el": {
+        "node_modules/@esbuild/linux-mips64el": {
             "version": "0.17.18",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.18.tgz",
             "integrity": "sha512-oVqckATOAGuiUOa6wr8TXaVPSa+6IwVJrGidmNZS1cZVx0HqkTMkqFGD2HIx9H1RvOwFeWYdaYbdY6B89KUMxA==",
+            "cpu": [
+                "mips64el"
+            ],
             "dev": true,
-            "optional": true
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
-        "@esbuild/linux-ppc64": {
+        "node_modules/@esbuild/linux-ppc64": {
             "version": "0.17.18",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.18.tgz",
             "integrity": "sha512-3dLlQO+b/LnQNxgH4l9rqa2/IwRJVN9u/bK63FhOPB4xqiRqlQAU0qDU3JJuf0BmaH0yytTBdoSBHrb2jqc5qQ==",
+            "cpu": [
+                "ppc64"
+            ],
             "dev": true,
-            "optional": true
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
-        "@esbuild/linux-riscv64": {
+        "node_modules/@esbuild/linux-riscv64": {
             "version": "0.17.18",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.18.tgz",
             "integrity": "sha512-/x7leOyDPjZV3TcsdfrSI107zItVnsX1q2nho7hbbQoKnmoeUWjs+08rKKt4AUXju7+3aRZSsKrJtaRmsdL1xA==",
+            "cpu": [
+                "riscv64"
+            ],
             "dev": true,
-            "optional": true
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
-        "@esbuild/linux-s390x": {
+        "node_modules/@esbuild/linux-s390x": {
             "version": "0.17.18",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.18.tgz",
             "integrity": "sha512-cX0I8Q9xQkL/6F5zWdYmVf5JSQt+ZfZD2bJudZrWD+4mnUvoZ3TDDXtDX2mUaq6upMFv9FlfIh4Gfun0tbGzuw==",
+            "cpu": [
+                "s390x"
+            ],
             "dev": true,
-            "optional": true
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
-        "@esbuild/linux-x64": {
+        "node_modules/@esbuild/linux-x64": {
             "version": "0.17.18",
             "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.18.tgz",
             "integrity": "sha512-66RmRsPlYy4jFl0vG80GcNRdirx4nVWAzJmXkevgphP1qf4dsLQCpSKGM3DUQCojwU1hnepI63gNZdrr02wHUA==",
+            "cpu": [
+                "x64"
+            ],
             "dev": true,
-            "optional": true
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
-        "@esbuild/netbsd-x64": {
+        "node_modules/@esbuild/netbsd-x64": {
             "version": "0.17.18",
             "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.18.tgz",
             "integrity": "sha512-95IRY7mI2yrkLlTLb1gpDxdC5WLC5mZDi+kA9dmM5XAGxCME0F8i4bYH4jZreaJ6lIZ0B8hTrweqG1fUyW7jbg==",
+            "cpu": [
+                "x64"
+            ],
             "dev": true,
-            "optional": true
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
-        "@esbuild/openbsd-x64": {
+        "node_modules/@esbuild/openbsd-x64": {
             "version": "0.17.18",
             "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.18.tgz",
             "integrity": "sha512-WevVOgcng+8hSZ4Q3BKL3n1xTv5H6Nb53cBrtzzEjDbbnOmucEVcZeGCsCOi9bAOcDYEeBZbD2SJNBxlfP3qiA==",
+            "cpu": [
+                "x64"
+            ],
             "dev": true,
-            "optional": true
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
-        "@esbuild/sunos-x64": {
+        "node_modules/@esbuild/sunos-x64": {
             "version": "0.17.18",
             "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.18.tgz",
             "integrity": "sha512-Rzf4QfQagnwhQXVBS3BYUlxmEbcV7MY+BH5vfDZekU5eYpcffHSyjU8T0xucKVuOcdCsMo+Ur5wmgQJH2GfNrg==",
+            "cpu": [
+                "x64"
+            ],
             "dev": true,
-            "optional": true
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
-        "@esbuild/win32-arm64": {
+        "node_modules/@esbuild/win32-arm64": {
             "version": "0.17.18",
             "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.18.tgz",
             "integrity": "sha512-Kb3Ko/KKaWhjeAm2YoT/cNZaHaD1Yk/pa3FTsmqo9uFh1D1Rfco7BBLIPdDOozrObj2sahslFuAQGvWbgWldAg==",
+            "cpu": [
+                "arm64"
+            ],
             "dev": true,
-            "optional": true
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
-        "@esbuild/win32-ia32": {
+        "node_modules/@esbuild/win32-ia32": {
             "version": "0.17.18",
             "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.18.tgz",
             "integrity": "sha512-0/xUMIdkVHwkvxfbd5+lfG7mHOf2FRrxNbPiKWg9C4fFrB8H0guClmaM3BFiRUYrznVoyxTIyC/Ou2B7QQSwmw==",
+            "cpu": [
+                "ia32"
+            ],
             "dev": true,
-            "optional": true
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
-        "@esbuild/win32-x64": {
+        "node_modules/@esbuild/win32-x64": {
             "version": "0.17.18",
             "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.18.tgz",
             "integrity": "sha512-qU25Ma1I3NqTSHJUOKi9sAH1/Mzuvlke0ioMJRthLXKm7JiSKVwFghlGbDLOO2sARECGhja4xYfRAZNPAkooYg==",
+            "cpu": [
+                "x64"
+            ],
             "dev": true,
-            "optional": true
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
-        "@vitejs/plugin-vue": {
+        "node_modules/@vitejs/plugin-vue": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.2.1.tgz",
             "integrity": "sha512-ZTZjzo7bmxTRTkb8GSTwkPOYDIP7pwuyV+RV53c9PYUouwcbkIZIvWvNWlX2b1dYZqtOv7D6iUAnJLVNGcLrSw==",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "peerDependencies": {
+                "vite": "^4.0.0",
+                "vue": "^3.2.25"
+            }
         },
-        "@vue/compiler-core": {
+        "node_modules/@vue/compiler-core": {
             "version": "3.2.36",
             "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.36.tgz",
             "integrity": "sha512-bbyZM5hvBicv0PW3KUfVi+x3ylHnfKG7DOn5wM+f2OztTzTjLEyBb/5yrarIYpmnGitVGbjZqDbODyW4iK8hqw==",
-            "requires": {
+            "dependencies": {
                 "@babel/parser": "^7.16.4",
                 "@vue/shared": "3.2.36",
                 "estree-walker": "^2.0.2",
                 "source-map": "^0.6.1"
             }
         },
-        "@vue/compiler-dom": {
+        "node_modules/@vue/compiler-dom": {
             "version": "3.2.36",
             "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.36.tgz",
             "integrity": "sha512-tcOTAOiW4s24QLnq+ON6J+GRONXJ+A/mqKCORi0LSlIh8XQlNnlm24y8xIL8la+ZDgkdbjarQ9ZqYSvEja6gVA==",
-            "requires": {
+            "dependencies": {
                 "@vue/compiler-core": "3.2.36",
                 "@vue/shared": "3.2.36"
             }
         },
-        "@vue/compiler-sfc": {
+        "node_modules/@vue/compiler-sfc": {
             "version": "3.2.36",
             "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.36.tgz",
             "integrity": "sha512-AvGb4bTj4W8uQ4BqaSxo7UwTEqX5utdRSMyHy58OragWlt8nEACQ9mIeQh3K4di4/SX+41+pJrLIY01lHAOFOA==",
-            "requires": {
+            "dependencies": {
                 "@babel/parser": "^7.16.4",
                 "@vue/compiler-core": "3.2.36",
                 "@vue/compiler-dom": "3.2.36",
@@ -204,28 +428,28 @@
                 "source-map": "^0.6.1"
             }
         },
-        "@vue/compiler-ssr": {
+        "node_modules/@vue/compiler-ssr": {
             "version": "3.2.36",
             "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.36.tgz",
             "integrity": "sha512-+KugInUFRvOxEdLkZwE+W43BqHyhBh0jpYXhmqw1xGq2dmE6J9eZ8UUSOKNhdHtQ/iNLWWeK/wPZkVLUf3YGaw==",
-            "requires": {
+            "dependencies": {
                 "@vue/compiler-dom": "3.2.36",
                 "@vue/shared": "3.2.36"
             }
         },
-        "@vue/reactivity": {
+        "node_modules/@vue/reactivity": {
             "version": "3.2.36",
             "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.36.tgz",
             "integrity": "sha512-c2qvopo0crh9A4GXi2/2kfGYMxsJW4tVILrqRPydVGZHhq0fnzy6qmclWOhBFckEhmyxmpHpdJtIRYGeKcuhnA==",
-            "requires": {
+            "dependencies": {
                 "@vue/shared": "3.2.36"
             }
         },
-        "@vue/reactivity-transform": {
+        "node_modules/@vue/reactivity-transform": {
             "version": "3.2.36",
             "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.36.tgz",
             "integrity": "sha512-Jk5o2BhpODC9XTA7o4EL8hSJ4JyrFWErLtClG3NH8wDS7ri9jBDWxI7/549T7JY9uilKsaNM+4pJASLj5dtRwA==",
-            "requires": {
+            "dependencies": {
                 "@babel/parser": "^7.16.4",
                 "@vue/compiler-core": "3.2.36",
                 "@vue/shared": "3.2.36",
@@ -233,122 +457,159 @@
                 "magic-string": "^0.25.7"
             }
         },
-        "@vue/runtime-core": {
+        "node_modules/@vue/runtime-core": {
             "version": "3.2.36",
             "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.36.tgz",
             "integrity": "sha512-PTWBD+Lub+1U3/KhbCExrfxyS14hstLX+cBboxVHaz+kXoiDLNDEYAovPtxeTutbqtClIXtft+wcGdC+FUQ9qQ==",
-            "requires": {
+            "dependencies": {
                 "@vue/reactivity": "3.2.36",
                 "@vue/shared": "3.2.36"
             }
         },
-        "@vue/runtime-dom": {
+        "node_modules/@vue/runtime-dom": {
             "version": "3.2.36",
             "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.36.tgz",
             "integrity": "sha512-gYPYblm7QXHVuBohqNRRT7Wez0f2Mx2D40rb4fleehrJU9CnkjG0phhcGEZFfGwCmHZRqBCRgbFWE98bPULqkg==",
-            "requires": {
+            "dependencies": {
                 "@vue/runtime-core": "3.2.36",
                 "@vue/shared": "3.2.36",
                 "csstype": "^2.6.8"
             }
         },
-        "@vue/server-renderer": {
+        "node_modules/@vue/server-renderer": {
             "version": "3.2.36",
             "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.36.tgz",
             "integrity": "sha512-uZE0+jfye6yYXWvAQYeHZv+f50sRryvy16uiqzk3jn8hEY8zTjI+rzlmZSGoE915k+W/Ol9XSw6vxOUD8dGkUg==",
-            "requires": {
+            "dependencies": {
                 "@vue/compiler-ssr": "3.2.36",
                 "@vue/shared": "3.2.36"
+            },
+            "peerDependencies": {
+                "vue": "3.2.36"
             }
         },
-        "@vue/shared": {
+        "node_modules/@vue/shared": {
             "version": "3.2.36",
             "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.36.tgz",
             "integrity": "sha512-JtB41wXl7Au3+Nl3gD16Cfpj7k/6aCroZ6BbOiCMFCMvrOpkg/qQUXTso2XowaNqBbnkuGHurLAqkLBxNGc1hQ=="
         },
-        "ansi-styles": {
+        "node_modules/ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "requires": {
+            "dependencies": {
                 "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
-        "asynckit": {
+        "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
             "dev": true
         },
-        "axios": {
+        "node_modules/axios": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
             "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
             "dev": true,
-            "requires": {
+            "dependencies": {
                 "follow-redirects": "^1.15.0",
                 "form-data": "^4.0.0",
                 "proxy-from-env": "^1.1.0"
             }
         },
-        "big.js": {
+        "node_modules/big.js": {
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-            "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+            "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+            "engines": {
+                "node": "*"
+            }
         },
-        "chalk": {
+        "node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "requires": {
+            "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
-        "color-convert": {
+        "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "requires": {
+            "dependencies": {
                 "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
             }
         },
-        "color-name": {
+        "node_modules/color-name": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
-        "combined-stream": {
+        "node_modules/combined-stream": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
             "dev": true,
-            "requires": {
+            "dependencies": {
                 "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
             }
         },
-        "csstype": {
+        "node_modules/csstype": {
             "version": "2.6.21",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
             "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
         },
-        "delayed-stream": {
+        "node_modules/delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=0.4.0"
+            }
         },
-        "emojis-list": {
+        "node_modules/emojis-list": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-            "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
+            "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+            "engines": {
+                "node": ">= 4"
+            }
         },
-        "esbuild": {
+        "node_modules/esbuild": {
             "version": "0.17.18",
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.18.tgz",
             "integrity": "sha512-z1lix43jBs6UKjcZVKOw2xx69ffE2aG0PygLL5qJ9OS/gy0Ewd1gW/PUQIOIQGXBHWNywSc0floSKoMFF8aK2w==",
             "dev": true,
-            "requires": {
+            "hasInstallScript": true,
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "optionalDependencies": {
                 "@esbuild/android-arm": "0.17.18",
                 "@esbuild/android-arm64": "0.17.18",
                 "@esbuild/android-x64": "0.17.18",
@@ -373,184 +634,323 @@
                 "@esbuild/win32-x64": "0.17.18"
             }
         },
-        "estree-walker": {
+        "node_modules/estree-walker": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
             "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
         },
-        "follow-redirects": {
+        "node_modules/follow-redirects": {
             "version": "1.15.2",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
             "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-            "dev": true
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
+            }
         },
-        "form-data": {
+        "node_modules/form-data": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
             "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
             "dev": true,
-            "requires": {
+            "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
-        "fsevents": {
+        "node_modules/fsevents": {
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
             "dev": true,
-            "optional": true
+            "hasInstallScript": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
         },
-        "has-flag": {
+        "node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "engines": {
+                "node": ">=8"
+            }
         },
-        "hash-sum": {
+        "node_modules/hash-sum": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
             "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg=="
         },
-        "json5": {
+        "node_modules/json5": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "bin": {
+                "json5": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
         },
-        "laravel-vite-plugin": {
+        "node_modules/laravel-vite-plugin": {
             "version": "0.7.4",
             "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-0.7.4.tgz",
             "integrity": "sha512-NlIuXbeuI+4NZzRpWNpGHRVTwuFWessvD7QoD+o2MlyAi7qyUS4J8r4/yTlu1dl9lxcR7iKoYUmHQqZDcrw2KA==",
             "dev": true,
-            "requires": {
+            "dependencies": {
                 "picocolors": "^1.0.0",
                 "vite-plugin-full-reload": "^1.0.5"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "vite": "^3.0.0 || ^4.0.0"
             }
         },
-        "loader-utils": {
+        "node_modules/loader-utils": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
             "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-            "requires": {
+            "dependencies": {
                 "big.js": "^5.2.2",
                 "emojis-list": "^3.0.0",
                 "json5": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=8.9.0"
             }
         },
-        "magic-string": {
+        "node_modules/magic-string": {
             "version": "0.25.9",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
             "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-            "requires": {
+            "dependencies": {
                 "sourcemap-codec": "^1.4.8"
             }
         },
-        "mime-db": {
+        "node_modules/mime-db": {
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
-        "mime-types": {
+        "node_modules/mime-types": {
             "version": "2.1.35",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
             "dev": true,
-            "requires": {
+            "dependencies": {
                 "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
             }
         },
-        "nanoid": {
+        "node_modules/nanoid": {
             "version": "3.3.6",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-            "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
+            "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
         },
-        "picocolors": {
+        "node_modules/picocolors": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
             "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
         },
-        "picomatch": {
+        "node_modules/picomatch": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "dev": true
+            "dev": true,
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
         },
-        "postcss": {
+        "node_modules/postcss": {
             "version": "8.4.23",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.23.tgz",
             "integrity": "sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==",
-            "requires": {
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "dependencies": {
                 "nanoid": "^3.3.6",
                 "picocolors": "^1.0.0",
                 "source-map-js": "^1.0.2"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
             }
         },
-        "proxy-from-env": {
+        "node_modules/proxy-from-env": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
             "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
             "dev": true
         },
-        "rollup": {
+        "node_modules/rollup": {
             "version": "3.21.5",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.21.5.tgz",
             "integrity": "sha512-a4NTKS4u9PusbUJcfF4IMxuqjFzjm6ifj76P54a7cKnvVzJaG12BLVR+hgU2YDGHzyMMQNxLAZWuALsn8q2oQg==",
             "dev": true,
-            "requires": {
+            "bin": {
+                "rollup": "dist/bin/rollup"
+            },
+            "engines": {
+                "node": ">=14.18.0",
+                "npm": ">=8.0.0"
+            },
+            "optionalDependencies": {
                 "fsevents": "~2.3.2"
             }
         },
-        "source-map": {
+        "node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "source-map-js": {
+        "node_modules/source-map-js": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
-        "sourcemap-codec": {
+        "node_modules/sourcemap-codec": {
             "version": "1.4.8",
             "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-            "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+            "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+            "deprecated": "Please use @jridgewell/sourcemap-codec instead"
         },
-        "supports-color": {
+        "node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "requires": {
+            "dependencies": {
                 "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
-        "vite": {
+        "node_modules/vite": {
             "version": "4.3.5",
             "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.5.tgz",
             "integrity": "sha512-0gEnL9wiRFxgz40o/i/eTBwm+NEbpUeTWhzKrZDSdKm6nplj+z4lKz8ANDgildxHm47Vg8EUia0aicKbawUVVA==",
             "dev": true,
-            "requires": {
+            "dependencies": {
                 "esbuild": "^0.17.5",
-                "fsevents": "~2.3.2",
                 "postcss": "^8.4.23",
                 "rollup": "^3.21.0"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
+            },
+            "peerDependencies": {
+                "@types/node": ">= 14",
+                "less": "*",
+                "sass": "*",
+                "stylus": "*",
+                "sugarss": "*",
+                "terser": "^5.4.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                }
             }
         },
-        "vite-plugin-full-reload": {
+        "node_modules/vite-plugin-full-reload": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/vite-plugin-full-reload/-/vite-plugin-full-reload-1.0.5.tgz",
             "integrity": "sha512-kVZFDFWr0DxiHn6MuDVTQf7gnWIdETGlZh0hvTiMXzRN80vgF4PKbONSq8U1d0WtHsKaFODTQgJeakLacoPZEQ==",
             "dev": true,
-            "requires": {
+            "dependencies": {
                 "picocolors": "^1.0.0",
                 "picomatch": "^2.3.1"
+            },
+            "peerDependencies": {
+                "vite": "^2 || ^3 || ^4"
             }
         },
-        "vue": {
+        "node_modules/vue": {
             "version": "3.2.36",
             "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.36.tgz",
             "integrity": "sha512-5yTXmrE6gW8IQgttzHW5bfBiFA6mx35ZXHjGLDmKYzW6MMmYvCwuKybANRepwkMYeXw2v1buGg3/lPICY5YlZw==",
-            "requires": {
+            "dependencies": {
                 "@vue/compiler-dom": "3.2.36",
                 "@vue/compiler-sfc": "3.2.36",
                 "@vue/runtime-dom": "3.2.36",
@@ -558,14 +958,25 @@
                 "@vue/shared": "3.2.36"
             }
         },
-        "vue-loader": {
+        "node_modules/vue-loader": {
             "version": "17.0.1",
             "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-17.0.1.tgz",
             "integrity": "sha512-/OOyugJnImKCkAKrAvdsWMuwoCqGxWT5USLsjohzWbMgOwpA5wQmzQiLMzZd7DjhIfunzAGIApTOgIylz/kwcg==",
-            "requires": {
+            "dependencies": {
                 "chalk": "^4.1.0",
                 "hash-sum": "^2.0.0",
                 "loader-utils": "^2.0.0"
+            },
+            "peerDependencies": {
+                "webpack": "^4.1.0 || ^5.0.0-0"
+            },
+            "peerDependenciesMeta": {
+                "@vue/compiler-sfc": {
+                    "optional": true
+                },
+                "vue": {
+                    "optional": true
+                }
             }
         }
     }


### PR DESCRIPTION
ERROR:
```console
$ ./vendor/bin/sail npm run dev

> dev
> vite

sh: 1: vite: not found
```

SOLUTION:
```console
$ ./vendor/bin/sail npm install
npm WARN old lockfile 
npm WARN old lockfile The package-lock.json file was created with an old version of npm,
npm WARN old lockfile so supplemental metadata must be fetched from the registry.
npm WARN old lockfile 
npm WARN old lockfile This is a one-time fix-up, please be patient...
npm WARN old lockfile 
npm WARN deprecated sourcemap-codec@1.4.8: Please use @jridgewell/sourcemap-codec instead

added 50 packages, and audited 51 packages in 2m

6 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

## Changed
* New lockfile (`package-lock.json`) generated by running `$ ./vendor/bin/sail npm install`