### PR TITLE
GraphQL post request using axios

### DIFF
--- a/app/Models/Question.php
+++ b/app/Models/Question.php
@@ -11,6 +11,7 @@ class Question extends Model
     use HasFactory;
 
     protected $fillable = ['title', 'body'];
+    public $table = 'questions';
     /**
      * Get the hints for the question.
      */

--- a/resources/components/App.vue
+++ b/resources/components/App.vue
@@ -1,11 +1,51 @@
 <template>
   <h1>Quiz app</h1>
+  <h2>Questions</h2>
+    <div class="post" v-for="questionData in quizDataList" v-bind:key="questionData.id">
+            <h3>Question: {{ questionData.title }}</h3>
+            <p>{{ questionData.body }}</p>
+
+            <h3>Hints</h3>
+        <ul>
+            <li class="just-the-hints" v-for="thehint in questionData.hints" :key="thehint.id">
+              {{ thehint.hint }}
+            </li>
+        </ul>
+        <hr>
+    </div>
 </template>
 
 <script>
 export default {
-  setup() {
-
-   }
-}
+        data() {
+            return {
+                quizDataList: []
+            };
+        },
+        async mounted() {
+            try {
+                var result = await axios({
+                    method: "POST",
+                    url: "http://0.0.0.0/graphql",
+                    data: {
+                        query: `
+                            {
+                                questions {
+                                    id
+                                    title
+                                    body
+                                    hints {
+                                      hint
+                                    }
+                                }
+                            }
+                        `
+                    }
+                });
+                this.quizDataList = result.data.data.questions;
+            } catch (error) {
+                console.error(error);
+            }
+        }
+    }
 </script>


### PR DESCRIPTION
## Changed
* 'App' component displays list of questions (each with all of its hints) *visually* when browse at URL http://0.0.0.0/, and directly via API at http://0.0.0.0/graphql?query={%0A%20%20questions%20{%0A%20%20%20%20id%0A%20%20%20%20title%0A%20%20%20%20body%0A%20%20%20%20hints%20{%0A%20%20%20%20%20%20hint%0A%20%20%20%20}%0A%20%20}%0A}%0A
  * Note: the URL above was from running the (corresponding) query at http://0.0.0.0/graphiql:
 ```console
{
      questions {
          id
          title
          body
          hints {
            hint
          }
      }
  }
  ```
  * Ensure that the db is seeded (prior to running the query):
```console
$ ./vendor/bin/sail php artisan config:cache --env=local
$ ./vendor/bin/sail php artisan migrate:refresh --seed

   INFO  Rolling back migrations.  

  2023_04_20_224629_create_hints_table ............................ 556ms DONE
  2023_04_20_223654_create_questions_table ........................ 598ms DONE
  2019_12_14_000001_create_personal_access_tokens_table ........... 909ms DONE
  2019_08_19_000000_create_failed_jobs_table ...................... 455ms DONE
  2014_10_12_100000_create_password_reset_tokens_table ............ 609ms DONE
  2014_10_12_000000_create_users_table .......................... 1,385ms DONE

   INFO  Loading stored database schemas.  

  database/schema/mysql-schema.sql .............................. 9,726ms DONE

   INFO  Nothing to migrate.  

   INFO  Seeding database.  

  Database\Seeders\QuestionSeeder .................................... RUNNING  
  Database\Seeders\QuestionSeeder ........................... 7,624.53 ms DONE  

  Database\Seeders\HintSeeder ........................................ RUNNING  
  Database\Seeders\HintSeeder ................................. 594.16 ms DONE 

$ ./vendor/bin/sail up
$ ./vendor/bin/sail npm run dev
```