### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,78 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+# Other jobs
+# ...
+  changelog:
+    name: Update Changelog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get version from tag
+        env:
+          GITHUB_REF: $
+        run: |
+          export CURRENT_VERSION=${GITHUB_ENV/refs\/tags\/v/}
+          echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: main
+          token: ${{ secrets.GH_PAT }}
+      - name: Update Changelog
+        uses: heinrichreimer/action-github-changelog-generator@v2.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issues: true
+          issuesWoLabels: true
+          pullRequests: true
+          prWoLabels: true
+          unreleased: true
+          addSections: '{"documentation":{"prefix":" **Documentation:**","labels":["documentation"]}}'
+      - uses: stefanzweifel/git-auto-commit-action@v4.16.0
+        with:
+          commit_message: ${{ github.event.head_commit.message }}
+          file_pattern: CHANGELOG.md
+
+  release_notes:
+    name: Create Release Notes
+    runs-on: ubuntu-latest
+    needs: changelog
+    steps:
+      - name: Get version from tag
+        env:
+          GITHUB_REF: $
+        run: |
+          export CURRENT_VERSION=${GITHUB_ENV/refs\/tags\/v/}
+          echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
+
+      - name: Checkout private repo
+        uses: actions/checkout@v2
+        with:
+          ref: main
+          repository: hfagerlund/quiz_app
+          token: ${{ secrets.GH_PAT }} # `GH_PAT` is a secret that contains your PAT
+          
+      - name: Get Changelog Entry
+        id: changelog_reader
+        uses: mindsers/changelog-reader-action@v2.2.2
+        with:
+          version: ${{ steps.tag_name.outputs.current_version }}
+          path: ./CHANGELOG.md
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1.1.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: ${{ steps.tag-data.outputs.git-tag-annotation }}
+          draft: false
+          prerelease: false
+


### PR DESCRIPTION
Resolves issue #44.

## Changed
* Add GitHub Actions workflow to automatically generate changelog and releases (including release notes based on tag annotations)