### PR TITLE
Add mutation tests

### DIFF
--- a/tests/Feature/QuestionTest.php
+++ b/tests/Feature/QuestionTest.php
@@ -31,6 +31,25 @@ class QuestionTest extends TestCase
         ->assertJsonFragment(['title' => $questions[0]->title]);
    }
 
+    public function test_questions_can_be_updated_via_api() {
+    $questions = Question::factory(\App\Models\Question::class)->count(2)->create();
+
+    $this->postJson('graphql', [
+          'query' => <<<GQL
+            mutation {
+              updateQuestion(id:1, title:"Test Title", body: "foo") {
+                title
+                body
+              }
+            }
+          GQL
+        ])
+        ->assertJsonFragment(['title' => 'Test Title'])
+        ->assertSee('Test')
+        ->assertDontSee('test') //case-sensitive
+        ->assertSeeText('foo');
+   }
+
    public function test_questions_have_attempts_field() {
     $questions = Question::factory(\App\Models\Question::class)->count(2)->create();
 

--- a/tests/components/QuestionsList.vue
+++ b/tests/components/QuestionsList.vue
@@ -48,7 +48,7 @@ export default {
                 this.dataReady = true;
                 this.quizDataList = result.data.data.questions;
             } catch (error) {
-                console.error(error);
+                //console.error(error);
             }
         }
     }


### PR DESCRIPTION
## Changed
* Added tests to verify that questions can be updated via the API (ie. mutation `updateQuestion` can be performed)

Run test using: 
```console
$ ./vendor/bin/sail up
$ ./vendor/bin/sail test --testsuite Feature --filter=QuestionTest
```