### PR TITLE
Fix Redis config file warning

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,8 @@ services:
         ports:
             - '${FORWARD_REDIS_PORT:-6379}:6379'
         volumes:
-            - 'sail-redis:/data'
+            - 'sail-redis:/usr/local/etc/redis/redis.conf:/data'
+        command: redis-server --include /usr/local/etc/redis/redis.conf
         networks:
             - sail
         healthcheck:


### PR DESCRIPTION
Resolves issue #4 .
## Changed

* Addition of 'redis-server' path under **both** 'command' and 'volumes' options under 'redis' (in docker-compose, for which Sail works as a wrapper) is required
## NOTE
> Also requires addition of a **redis.conf file (for Redis v7.0.11)]** locally in `/usr/local/etc/redis/` directory
> - Source: https://redis.io/docs/management/config/ > 'The self documented [redis.conf for Redis 7.0](https://raw.githubusercontent.com/redis/redis/7.0/redis.conf).')