### PR TITLE
Streamline Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+# anything not needed to run the app without Docker
+.git
+.dockerignore
+.gitignore
+.*ignore
+/.github
+.editorconfig
+.gitattributes
+docker-compose*.yml
+Dockerfile*
+CHANGELOG.md
+README.md
+*.log
+/tests
+/node_modules
+
+# environment variables (if defined in docker-compose.yml)
+.env*
+phpunit.xml


### PR DESCRIPTION
## Changed
* Add .dockerignore
  * ignores anything not needed to run the app without Docker;
  * ignores environment variables (if defined in docker-compose.yml).

### How to test
The following outputs a **list of files** (ignored based on `.dockerignore`), and their **total size** (at the end):
```console
$ rsync -avn . /tmp/my-docker-testing --exclude-from .dockerignore > ~/Desktop/list-of-files-copied-by-rsync.txt
```
(The above is modified from [this answer](https://stackoverflow.com/questions/38946683/how-to-test-dockerignore-file) (changes based on [this answer](https://superuser.com/questions/45342/when-should-i-use-dev-shm-and-when-should-i-use-tmp)).)